### PR TITLE
[index.html] removed link to defunct insight.is URL

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -65,7 +65,7 @@
         <a href="tx/send" translate>broadcast transaction</a>
         ]
       </div>
-      <a class="insight m10v pull-right" target="_blank" href="http://insight.is">insight <small>API v{{version}}</small></a>
+      <a class="insight m10v pull-right" target="_blank" href="">insight <small>API v{{version}}</small></a>
     </div>
   </div>
   <script language="javascript">window.apiPrefix = '/api';</script>


### PR DESCRIPTION
The insight-ui currently includes a link to insight.is, which used to be controlled by the developers of insight but is now an unrelated gambling website. Simplest solution is to remove the link. 